### PR TITLE
fix: (postgresql/tasks/postgres-macos) update to use wanted_postgresql_version variable

### DIFF
--- a/roles/postgresql/tasks/postgres-macos.yml
+++ b/roles/postgresql/tasks/postgres-macos.yml
@@ -1,10 +1,10 @@
 - name: Install postgresql using homebrew
   community.general.homebrew:
     update_homebrew: yes
-    name: postgres
+    name: "postgresql@{{wanted_postgresql_version}}"
     state: present
-- name: Start postgresl
-  command: brew services start postgresql
+- name: Start postgresql
+  command: "brew services start postgresql@{{wanted_postgresql_version}}"
 - name: Check for default database
   command: "psql {{ ansible_user_id }} -c '\\q'"
   register: default_database


### PR DESCRIPTION
`brew install postgresql` has been deprecated and replaced with `brew install postgresql@14`. It's been updated using the established `wanted_postgresql_version` variable

<img width="553" alt="Screen Shot 2022-11-02 at 3 27 11 PM" src="https://user-images.githubusercontent.com/80236622/199603845-56781968-7a58-4fc2-9b24-5321d0ee9107.png">

![Screen Shot 2022-11-02 at 5 16 24 PM](https://user-images.githubusercontent.com/80236622/199604099-798c20e8-61cf-4c88-b147-e81a6689792c.png)
